### PR TITLE
Implement Telegram GitHub watcher bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bot.sqlite
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
+# Telegram GitHub Watcher Bot
 
+This project provides a simple Telegram bot that monitors a GitHub repository for new events and sends notifications to a chat.
+
+## Requirements
+
+- Python 3.11+
+- Telegram bot token
+- GitHub repository name (e.g. `owner/repo`)
+- Chat ID where notifications will be sent
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Set the following environment variables before running:
+
+- `TELEGRAM_TOKEN` – token of your Telegram bot
+- `TELEGRAM_CHAT_ID` – chat ID to send messages to
+- `GITHUB_REPOSITORY` – repository in `owner/repo` format
+
+Start the bot:
+
+```bash
+python -m bot.github_bot
+```
+
+The bot stores state in `bot.sqlite` using SQLite. It periodically checks the GitHub Events API and posts new events to the configured Telegram chat.

--- a/bot/database.py
+++ b/bot/database.py
@@ -1,0 +1,32 @@
+import sqlite3
+from contextlib import closing
+
+DB_PATH = 'bot.sqlite'
+
+CREATE_TABLE_SQL = '''\
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+'''
+
+class Database:
+    def __init__(self, path: str = DB_PATH):
+        self.path = path
+        self._init_db()
+
+    def _init_db(self):
+        with closing(sqlite3.connect(self.path)) as conn:
+            conn.execute(CREATE_TABLE_SQL)
+            conn.commit()
+
+    def get(self, key: str) -> str | None:
+        with closing(sqlite3.connect(self.path)) as conn:
+            cur = conn.execute('SELECT value FROM settings WHERE key=?', (key,))
+            row = cur.fetchone()
+            return row[0] if row else None
+
+    def set(self, key: str, value: str):
+        with closing(sqlite3.connect(self.path)) as conn:
+            conn.execute('REPLACE INTO settings (key, value) VALUES (?, ?)', (key, value))
+            conn.commit()

--- a/bot/github_bot.py
+++ b/bot/github_bot.py
@@ -1,0 +1,77 @@
+import asyncio
+import logging
+import os
+from datetime import datetime
+
+import requests
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+from .database import Database
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+GITHUB_API = 'https://api.github.com'
+CHECK_INTERVAL = 60  # seconds
+
+class GitHubWatcher:
+    def __init__(self, repo: str, db: Database):
+        self.repo = repo
+        self.db = db
+
+    def _get_last_event_id(self) -> str | None:
+        return self.db.get(f'last_event_{self.repo}')
+
+    def _set_last_event_id(self, event_id: str):
+        self.db.set(f'last_event_{self.repo}', event_id)
+
+    async def check(self, send_callback):
+        url = f'{GITHUB_API}/repos/{self.repo}/events'
+        logger.info('Checking GitHub events for %s', self.repo)
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+        except Exception as e:
+            logger.error('GitHub request failed: %s', e)
+            return
+        events = resp.json()
+        if not events:
+            return
+        last_event_id = self._get_last_event_id()
+        new_events = []
+        for event in events:
+            if event['id'] == last_event_id:
+                break
+            new_events.append(event)
+        if new_events:
+            self._set_last_event_id(new_events[0]['id'])
+            for event in reversed(new_events):
+                text = f"New GitHub event on {self.repo}: {event['type']} at {event['created_at']}"
+                await send_callback(text)
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await update.message.reply_text('GitHub watcher bot is running.')
+
+async def main():
+    token = os.getenv('TELEGRAM_TOKEN')
+    repo = os.getenv('GITHUB_REPOSITORY')
+    if not token or not repo:
+        raise SystemExit('TELEGRAM_TOKEN and GITHUB_REPOSITORY must be set')
+    db = Database()
+    app = ApplicationBuilder().token(token).build()
+    watcher = GitHubWatcher(repo, db)
+    async def send(text):
+        await app.bot.send_message(chat_id=os.getenv('TELEGRAM_CHAT_ID'), text=text)
+    async def periodic():
+        while True:
+            await watcher.check(send)
+            await asyncio.sleep(CHECK_INTERVAL)
+    app.add_handler(CommandHandler('start', start))
+    async with app:
+        task = asyncio.create_task(periodic())
+        await app.run_polling()
+        task.cancel()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot==20.6
+requests>=2.0


### PR DESCRIPTION
## Summary
- add a simple Telegram bot that watches a GitHub repo for new events
- keep bot state in a SQLite database
- document how to run the bot
- ignore generated files

## Testing
- `pip install -r requirements.txt`
- `TELEGRAM_TOKEN=dummy GITHUB_REPOSITORY=owner/repo TELEGRAM_CHAT_ID=123 python -m bot.github_bot` *(fails: InvalidToken)*

------
https://chatgpt.com/codex/tasks/task_e_6889fc8667ac832f821c2789865c67f2