### PR TITLE
Add Telegram to Discord forwarding service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.venv/
+
+# Coverage
+htmlcov/
+.coverage*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
+# Telegram ➜ Discord Bridge Bot
 
+A lightweight Python service that forwards messages from a configured Telegram chat to a Discord
+channel using either a Discord webhook or bot token.
+
+## Features
+
+- Polls Telegram with the `telebot` library and forwards supported messages to Discord.
+- Supports text, links, photos, videos, documents, audio, voice messages, and animations.
+- Preserves author names and timestamps in forwarded messages.
+- Downloads Telegram attachments and uploads them directly to Discord.
+- Works with Discord webhooks or direct bot token/channel combinations.
+- Provides structured logging and basic error handling.
+
+## Requirements
+
+- Python 3.12+
+- Telegram bot token and chat ID.
+- Discord webhook URL **or** bot token plus channel ID.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Create a JSON configuration file (for example `config.json`) with the following structure:
+
+```json
+{
+  "telegram": {
+    "bot_token": "123456789:ABCDEF...",
+    "chat_id": 123456789
+  },
+  "discord": {
+    "webhook_url": "https://discord.com/api/webhooks/..."
+  },
+  "polling_interval": 2.0
+}
+```
+
+If you prefer to use a Discord bot token instead of a webhook, provide the `bot_token` and
+`channel_id` fields instead of `webhook_url`:
+
+```json
+  "discord": {
+    "bot_token": "bot-token-value",
+    "channel_id": 9876543210
+  }
+```
+
+Only one sending mode is required: webhook or bot token + channel ID.
+
+## Running the bot
+
+```bash
+python -m bridgebot path/to/config.json
+```
+
+The bot runs an infinite polling loop suitable for VPS or long-running environments. Configure the
+process manager of your choice (systemd, supervisord, Docker, etc.) to keep it alive 24/7.
+
+## Logging
+
+Logs are printed to stdout in the following format:
+
+```
+2024-04-10 13:37:00,123 [INFO] bridgebot.bridge: Starting Telegram polling loop
+2024-04-10 13:37:05,456 [INFO] bridgebot.forwarder: Forwarded message from Alice
+```
+
+## Development
+
+Install development dependencies and run the test suite:
+
+```bash
+pip install -r requirements-dev.txt
+pytest -q
+ruff .
+```
+
+The project is formatted with `black` (line length 100) and type hints are required throughout the
+codebase.

--- a/bridgebot/__init__.py
+++ b/bridgebot/__init__.py
@@ -1,0 +1,12 @@
+"""Bridgebot package for forwarding Telegram messages to Discord."""
+
+from bridgebot.bridge import BridgeBot
+from bridgebot.config import Config, DiscordConfig, TelegramConfig, load_config
+
+__all__ = [
+    "BridgeBot",
+    "Config",
+    "DiscordConfig",
+    "TelegramConfig",
+    "load_config",
+]

--- a/bridgebot/__main__.py
+++ b/bridgebot/__main__.py
@@ -1,0 +1,45 @@
+"""CLI entry point for the bridge bot."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from bridgebot.bridge import BridgeBot
+from bridgebot.config import ConfigError, load_config
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description="Telegram to Discord bridge bot")
+    parser.add_argument("config", type=Path, help="Path to the configuration JSON file")
+    return parser.parse_args()
+
+
+def configure_logging() -> None:
+    """Configure basic logging output."""
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def main() -> None:
+    """Run the bridge bot."""
+
+    args = parse_args()
+    configure_logging()
+    try:
+        config = load_config(args.config)
+    except ConfigError as exc:
+        logging.getLogger(__name__).error("Configuration error: %s", exc)
+        raise SystemExit(2) from exc
+    bot = BridgeBot(config)
+    bot.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/bridgebot/bridge.py
+++ b/bridgebot/bridge.py
@@ -1,0 +1,166 @@
+"""Telegram to Discord bridge implementation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable, List
+import logging
+
+from telebot import TeleBot
+from telebot.types import Message
+
+from bridgebot.config import Config
+from bridgebot.forwarder import Attachment, DiscordForwarder
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BridgeBot:
+    """Bridge that forwards Telegram messages to Discord."""
+
+    SUPPORTED_CONTENT_TYPES = [
+        "text",
+        "photo",
+        "video",
+        "document",
+        "animation",
+        "audio",
+        "voice",
+    ]
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+        self._telegram_bot = TeleBot(config.telegram.bot_token, parse_mode=None)
+        self._forwarder = DiscordForwarder(config.discord)
+        self._register_handlers()
+
+    def _register_handlers(self) -> None:
+        """Register message handler for the Telegram bot."""
+
+        self._telegram_bot.add_message_handler(
+            {
+                "function": self._handle_message,
+                "filters": {
+                    "content_types": self.SUPPORTED_CONTENT_TYPES,
+                    "func": self._is_target_chat,
+                },
+            }
+        )
+
+    def run(self) -> None:
+        """Start polling Telegram for new messages."""
+
+        LOGGER.info("Starting Telegram polling loop")
+        self._telegram_bot.infinity_polling(interval=self._config.polling_interval, timeout=20)
+
+    def _is_target_chat(self, message: Message) -> bool:
+        """Check whether a message comes from the configured chat."""
+
+        return message.chat.id == self._config.telegram.chat_id
+
+    def _handle_message(self, message: Message) -> None:
+        """Forward incoming Telegram messages to Discord."""
+
+        try:
+            author = self._resolve_author(message)
+            timestamp = datetime.fromtimestamp(message.date, tz=timezone.utc)
+            content = self._compose_content(message)
+            attachments = list(self._collect_attachments(message))
+            self._forwarder.send(
+                author=author, timestamp=timestamp, content=content, attachments=attachments
+            )
+        except Exception as exc:  # pragma: no cover - log and continue
+            LOGGER.exception("Failed to forward message: %s", exc)
+
+    @staticmethod
+    def _resolve_author(message: Message) -> str:
+        """Determine the display name of the Telegram message author."""
+
+        if message.from_user is None:
+            return "Unknown"
+        name_parts = [message.from_user.first_name or "", message.from_user.last_name or ""]
+        name = " ".join(part for part in name_parts if part).strip()
+        if not name:
+            return message.from_user.username or "Unknown"
+        return name
+
+    def _compose_content(self, message: Message) -> str:
+        """Build the textual content to send to Discord."""
+
+        pieces: List[str] = []
+        if message.text:
+            pieces.append(message.text)
+        if message.caption:
+            pieces.append(message.caption)
+        if message.content_type == "voice":
+            pieces.append("[Voice message]")
+        elif message.content_type == "audio":
+            pieces.append("[Audio clip]")
+        elif message.content_type == "animation":
+            pieces.append("[Animation]")
+        elif message.content_type == "document" and not message.text:
+            pieces.append(f"[Document] {message.document.file_name or ''}".strip())
+        elif message.content_type == "video" and not message.caption:
+            pieces.append("[Video]")
+        elif message.content_type == "photo" and not message.caption:
+            pieces.append("[Photo]")
+        if not pieces:
+            pieces.append("(no text content)")
+        return "\n".join(pieces)
+
+    def _collect_attachments(self, message: Message) -> Iterable[Attachment]:
+        """Collect attachments from a Telegram message."""
+
+        if message.photo:
+            photo = message.photo[-1]
+            yield self._download_attachment(photo.file_id, photo.file_unique_id, "image/jpeg")
+        if message.video:
+            yield self._download_attachment(
+                message.video.file_id,
+                message.video.file_unique_id,
+                message.video.mime_type or "video/mp4",
+                suggested_name=message.video.file_name,
+            )
+        if message.document:
+            yield self._download_attachment(
+                message.document.file_id,
+                message.document.file_unique_id,
+                message.document.mime_type or "application/octet-stream",
+                suggested_name=message.document.file_name,
+            )
+        if message.audio:
+            yield self._download_attachment(
+                message.audio.file_id,
+                message.audio.file_unique_id,
+                message.audio.mime_type or "audio/mpeg",
+                suggested_name=message.audio.file_name,
+            )
+        if message.voice:
+            yield self._download_attachment(
+                message.voice.file_id,
+                message.voice.file_unique_id,
+                message.voice.mime_type or "audio/ogg",
+                suggested_name="voice-message.ogg",
+            )
+        if message.animation:
+            yield self._download_attachment(
+                message.animation.file_id,
+                message.animation.file_unique_id,
+                message.animation.mime_type or "image/gif",
+                suggested_name=message.animation.file_name,
+            )
+
+    def _download_attachment(
+        self,
+        file_id: str,
+        unique_id: str,
+        content_type: str,
+        *,
+        suggested_name: str | None = None,
+    ) -> Attachment:
+        """Download a file from Telegram and build an :class:`Attachment`."""
+
+        file_info = self._telegram_bot.get_file(file_id)
+        data = self._telegram_bot.download_file(file_info.file_path)
+        filename = suggested_name or f"{unique_id}"
+        return Attachment(filename=filename, content=data, content_type=content_type)

--- a/bridgebot/config.py
+++ b/bridgebot/config.py
@@ -1,0 +1,131 @@
+"""Configuration handling for the Telegram to Discord bridge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+import json
+
+
+class ConfigError(Exception):
+    """Raised when configuration loading or validation fails."""
+
+
+@dataclass
+class TelegramConfig:
+    """Telegram configuration options.
+
+    Attributes:
+        bot_token: Token for the Telegram bot provided by BotFather.
+        chat_id: Numeric identifier of the Telegram chat to monitor.
+    """
+
+    bot_token: str
+    chat_id: int
+
+
+@dataclass
+class DiscordConfig:
+    """Discord configuration options.
+
+    Attributes:
+        webhook_url: Discord webhook URL for posting messages.
+        bot_token: Discord bot token used for the HTTP Bot API.
+        channel_id: Target Discord channel identifier.
+    """
+
+    webhook_url: Optional[str] = None
+    bot_token: Optional[str] = None
+    channel_id: Optional[int] = None
+
+    def validate(self) -> None:
+        """Validate the configuration and raise an error if invalid."""
+
+        if self.webhook_url:
+            return
+        if self.bot_token and self.channel_id:
+            return
+        raise ConfigError(
+            "Discord configuration requires either a webhook_url or both bot_token and channel_id."
+        )
+
+
+@dataclass
+class Config:
+    """Combined configuration for the bridge bot."""
+
+    telegram: TelegramConfig
+    discord: DiscordConfig
+    polling_interval: float = 2.0
+
+
+def _read_file(path: Path) -> Dict[str, Any]:
+    """Read a JSON file and return the parsed content."""
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:  # pragma: no cover - thin wrapper
+        raise ConfigError(f"Configuration file not found: {path}") from exc
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"Invalid JSON configuration: {exc}") from exc
+
+
+def _parse_telegram_config(data: Dict[str, Any]) -> TelegramConfig:
+    """Parse the Telegram configuration section."""
+
+    try:
+        bot_token = data["bot_token"]
+        chat_id = int(data["chat_id"])
+    except KeyError as exc:
+        raise ConfigError(f"Missing Telegram configuration value: {exc.args[0]}") from exc
+    except (TypeError, ValueError) as exc:
+        raise ConfigError("chat_id must be an integer") from exc
+    if not bot_token:
+        raise ConfigError("bot_token must not be empty")
+    return TelegramConfig(bot_token=bot_token, chat_id=chat_id)
+
+
+def _parse_discord_config(data: Dict[str, Any]) -> DiscordConfig:
+    """Parse the Discord configuration section."""
+
+    config = DiscordConfig(
+        webhook_url=data.get("webhook_url"),
+        bot_token=data.get("bot_token"),
+        channel_id=_parse_optional_int(data.get("channel_id")),
+    )
+    config.validate()
+    return config
+
+
+def _parse_optional_int(value: Any) -> Optional[int]:
+    """Convert a value to an integer when possible."""
+
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError("channel_id must be an integer") from exc
+
+
+def load_config(path: str | Path) -> Config:
+    """Load configuration from a JSON file.
+
+    Args:
+        path: Path to the configuration JSON file.
+
+    Returns:
+        A validated :class:`Config` object.
+    """
+
+    raw = _read_file(Path(path))
+    try:
+        telegram = _parse_telegram_config(raw["telegram"])
+        discord = _parse_discord_config(raw["discord"])
+    except KeyError as exc:
+        raise ConfigError(f"Missing top-level configuration section: {exc.args[0]}") from exc
+    polling_interval = float(raw.get("polling_interval", 2.0))
+    return Config(telegram=telegram, discord=discord, polling_interval=polling_interval)

--- a/bridgebot/forwarder.py
+++ b/bridgebot/forwarder.py
@@ -1,0 +1,104 @@
+"""Discord forwarding utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, List, Optional
+import logging
+
+import requests
+
+from bridgebot.config import DiscordConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Attachment:
+    """File attachment for Discord uploads."""
+
+    filename: str
+    content: bytes
+    content_type: Optional[str] = None
+
+
+def format_prefix(author: str, timestamp: datetime) -> str:
+    """Format the prefix containing the author and timestamp."""
+
+    formatted_ts = timestamp.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    return f"From {author} at {formatted_ts}:"
+
+
+class DiscordForwarder:
+    """Forward messages to Discord using webhook or bot credentials."""
+
+    def __init__(self, config: DiscordConfig) -> None:
+        self._config = config
+        self._session = requests.Session()
+
+    def send(
+        self,
+        author: str,
+        timestamp: datetime,
+        content: str,
+        attachments: Optional[Iterable[Attachment]] = None,
+    ) -> None:
+        """Send a message to Discord."""
+
+        attachments_list = list(attachments or [])
+        payload = {"content": f"{format_prefix(author, timestamp)}\n{content}".strip()}
+        LOGGER.debug("Dispatching message to Discord: %s", payload["content"])
+        if self._config.webhook_url:
+            self._send_via_webhook(payload, attachments_list)
+        else:
+            self._send_via_bot_api(payload, attachments_list)
+        LOGGER.info("Forwarded message from %s", author)
+
+    def _send_via_webhook(self, payload: dict, attachments: List[Attachment]) -> None:
+        """Send the payload using a Discord webhook."""
+
+        files = self._prepare_files(attachments)
+        response = self._session.post(
+            self._config.webhook_url, data={"content": payload["content"]}, files=files
+        )
+        self._handle_response(response)
+
+    def _send_via_bot_api(self, payload: dict, attachments: List[Attachment]) -> None:
+        """Send the payload using the Discord Bot API."""
+
+        if not (self._config.bot_token and self._config.channel_id):  # pragma: no cover - guard
+            raise RuntimeError("Bot API configuration is incomplete")
+        url = f"https://discord.com/api/v10/channels/{self._config.channel_id}/messages"
+        headers = {"Authorization": f"Bot {self._config.bot_token}"}
+        data = {"content": payload["content"]}
+        files = self._prepare_files(attachments)
+        response = self._session.post(url, data=data, headers=headers, files=files)
+        self._handle_response(response)
+
+    def _prepare_files(self, attachments: List[Attachment]) -> Optional[List[tuple]]:
+        """Prepare multipart files payload for Discord uploads."""
+
+        if not attachments:
+            return None
+        files = []
+        for index, attachment in enumerate(attachments):
+            files.append(
+                (
+                    f"files[{index}]",
+                    (
+                        attachment.filename,
+                        attachment.content,
+                        attachment.content_type or "application/octet-stream",
+                    ),
+                )
+            )
+        return files
+
+    @staticmethod
+    def _handle_response(response: requests.Response) -> None:
+        """Validate the HTTP response from Discord."""
+
+        if response.status_code >= 400:
+            LOGGER.error("Discord API error: %s - %s", response.status_code, response.text)
+            response.raise_for_status()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+black==24.4.2
+pytest==8.2.0
+ruff==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyTelegramBotAPI>=4.14,<5.0
+requests>=2.31,<3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Pytest configuration for tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def _install_telebot_stub() -> None:
+    """Install a lightweight telebot stub for tests."""
+
+    if "telebot" in sys.modules:
+        return
+    telebot_module = ModuleType("telebot")
+    telebot_module.TeleBot = SimpleNamespace  # type: ignore[attr-defined]
+    types_module = ModuleType("telebot.types")
+    types_module.Message = SimpleNamespace  # type: ignore[attr-defined]
+    sys.modules["telebot"] = telebot_module
+    sys.modules["telebot.types"] = types_module
+
+
+def _install_requests_stub() -> None:
+    """Install a lightweight requests stub for tests."""
+
+    if "requests" in sys.modules:
+        return
+    requests_module = ModuleType("requests")
+
+    class _Session:
+        def post(self, *args, **kwargs):  # pragma: no cover - replaced in tests
+            raise NotImplementedError
+
+    requests_module.Session = _Session  # type: ignore[attr-defined]
+    sys.modules["requests"] = requests_module
+
+
+_install_requests_stub()
+
+
+_install_telebot_stub()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,106 @@
+"""Tests for the bridge logic."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+import pytest
+
+from bridgebot.bridge import BridgeBot
+from bridgebot.config import Config, DiscordConfig, TelegramConfig
+
+
+class StubTeleBot:
+    """Minimal TeleBot stub for testing."""
+
+    def __init__(self, *_: Any, **__: Any) -> None:
+        self.handlers: List[Dict[str, Any]] = []
+        self.files: Dict[str, bytes] = {}
+
+    def add_message_handler(self, handler: Dict[str, Any]) -> None:
+        self.handlers.append(handler)
+
+    def get_file(self, file_id: str) -> SimpleNamespace:
+        return SimpleNamespace(file_path=f"path/{file_id}")
+
+    def download_file(self, file_path: str) -> bytes:
+        return self.files.get(file_path, b"data")
+
+    def infinity_polling(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - not invoked
+        raise AssertionError("Polling should not be invoked in tests")
+
+
+@pytest.fixture(autouse=True)
+def patch_telebot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch TeleBot with a stub for all tests in this module."""
+
+    monkeypatch.setattr("bridgebot.bridge.TeleBot", StubTeleBot)
+
+
+@pytest.fixture()
+def bridge_bot() -> BridgeBot:
+    """Create a bridge bot with stubbed dependencies."""
+
+    config = Config(
+        telegram=TelegramConfig(bot_token="token", chat_id=1),
+        discord=DiscordConfig(webhook_url="https://discord"),
+        polling_interval=0.1,
+    )
+    bot = BridgeBot(config)
+    return bot
+
+
+def make_user(first_name: str = "Alice", last_name: str | None = None, username: str | None = None):
+    return SimpleNamespace(first_name=first_name, last_name=last_name, username=username)
+
+
+def test_resolve_author_prefers_full_name(bridge_bot: BridgeBot) -> None:
+    """Author resolution prefers full names."""
+
+    message = SimpleNamespace(from_user=make_user(last_name="Smith"))
+    assert bridge_bot._resolve_author(message) == "Alice Smith"
+
+
+def test_resolve_author_uses_username(bridge_bot: BridgeBot) -> None:
+    """Username is used when no names are provided."""
+
+    message = SimpleNamespace(from_user=make_user(first_name="", last_name="", username="alias"))
+    assert bridge_bot._resolve_author(message) == "alias"
+
+
+def test_compose_content_handles_document(bridge_bot: BridgeBot) -> None:
+    """Document messages include the file name when no text is present."""
+
+    document = SimpleNamespace(
+        file_id="doc", file_unique_id="u_doc", file_name="report.pdf", mime_type="application/pdf"
+    )
+    message = SimpleNamespace(
+        text=None,
+        caption=None,
+        content_type="document",
+        document=document,
+        photo=None,
+        video=None,
+        audio=None,
+        voice=None,
+        animation=None,
+    )
+    assert "report.pdf" in bridge_bot._compose_content(message)
+
+
+def test_collect_attachments_downloads_files(bridge_bot: BridgeBot) -> None:
+    """Attachments are downloaded with the correct filenames."""
+
+    bridge_bot._telegram_bot.files["path/photo"] = b"image"
+    photo = SimpleNamespace(file_id="photo", file_unique_id="photo_id")
+    message = SimpleNamespace(
+        photo=[photo],
+        video=None,
+        document=None,
+        audio=None,
+        voice=None,
+        animation=None,
+    )
+    attachments = list(bridge_bot._collect_attachments(message))
+    assert attachments[0].filename == "photo_id"
+    assert attachments[0].content == b"image"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,55 @@
+"""Tests for configuration parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import pytest
+
+from bridgebot.config import ConfigError, load_config
+
+
+@pytest.fixture()
+def config_file(tmp_path: Path) -> Path:
+    """Create a temporary configuration file."""
+
+    data = {
+        "telegram": {"bot_token": "token", "chat_id": 123},
+        "discord": {"webhook_url": "https://example.com/webhook"},
+        "polling_interval": 1.5,
+    }
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def test_load_config_success(config_file: Path) -> None:
+    """Configuration loads and validates correctly."""
+
+    config = load_config(config_file)
+    assert config.telegram.bot_token == "token"
+    assert config.telegram.chat_id == 123
+    assert config.discord.webhook_url == "https://example.com/webhook"
+    assert config.polling_interval == 1.5
+
+
+def test_missing_sections(tmp_path: Path) -> None:
+    """Missing sections raise an error."""
+
+    path = tmp_path / "config.json"
+    path.write_text("{}", encoding="utf-8")
+    with pytest.raises(ConfigError):
+        load_config(path)
+
+
+def test_invalid_discord_config(tmp_path: Path) -> None:
+    """Invalid Discord configuration is rejected."""
+
+    data = {
+        "telegram": {"bot_token": "token", "chat_id": 123},
+        "discord": {},
+    }
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    with pytest.raises(ConfigError):
+        load_config(path)

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -1,0 +1,87 @@
+"""Tests for the Discord forwarder."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List
+import pytest
+
+from bridgebot.config import DiscordConfig
+from bridgebot.forwarder import Attachment, DiscordForwarder, format_prefix
+
+
+class DummyResponse:
+    """A fake response object for testing."""
+
+    def __init__(self, status_code: int = 200, text: str = "OK") -> None:
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:  # pragma: no cover - not triggered in tests
+            raise RuntimeError("HTTP error")
+
+
+class DummySession:
+    """A fake requests session that captures payloads."""
+
+    def __init__(self) -> None:
+        self.calls: List[dict] = []
+
+    def post(self, url: str, data=None, headers=None, files=None):  # type: ignore[override]
+        self.calls.append({"url": url, "data": data, "headers": headers, "files": files})
+        return DummyResponse()
+
+
+@pytest.fixture()
+def dummy_session(monkeypatch: pytest.MonkeyPatch) -> DummySession:
+    """Patch requests.Session to return a dummy session."""
+
+    session = DummySession()
+
+    class SessionFactory:
+        def __call__(self) -> DummySession:
+            return session
+
+    monkeypatch.setattr("bridgebot.forwarder.requests.Session", SessionFactory())
+    return session
+
+
+def test_format_prefix() -> None:
+    """Formatting includes the UTC timestamp."""
+
+    timestamp = datetime(2024, 5, 4, 12, 0, tzinfo=timezone.utc)
+    assert format_prefix("Alice", timestamp) == "From Alice at 2024-05-04 12:00:00 UTC:"
+
+
+def test_send_via_webhook(dummy_session: DummySession) -> None:
+    """Forwarder posts to the webhook endpoint."""
+
+    config = DiscordConfig(webhook_url="https://discord.test")
+    forwarder = DiscordForwarder(config)
+    forwarder.send(
+        author="Alice",
+        timestamp=datetime(2024, 5, 4, 12, 0, tzinfo=timezone.utc),
+        content="Hello",
+        attachments=[Attachment(filename="file.txt", content=b"data", content_type="text/plain")],
+    )
+    call = dummy_session.calls[0]
+    assert call["url"] == "https://discord.test"
+    assert "From Alice" in call["data"]["content"]
+    assert call["files"][0][0] == "files[0]"
+
+
+def test_send_via_bot_api(dummy_session: DummySession) -> None:
+    """Forwarder posts to the Bot API when configured."""
+
+    config = DiscordConfig(bot_token="token", channel_id=987654321)
+    forwarder = DiscordForwarder(config)
+    forwarder.send(
+        author="Bob",
+        timestamp=datetime(2024, 5, 4, 12, 0, tzinfo=timezone.utc),
+        content="Hi",
+        attachments=[],
+    )
+    call = dummy_session.calls[0]
+    assert call["url"] == "https://discord.com/api/v10/channels/987654321/messages"
+    assert call["headers"]["Authorization"] == "Bot token"


### PR DESCRIPTION
## Summary
- implement a Telegram to Discord bridge package with configuration, forwarding, and CLI entrypoint
- add dependency manifests and pytest configuration helpers for local execution
- document setup and usage steps in the README

## Testing
```text
$ ruff check .
All checks passed!

$ pytest -q
..........
10 passed in 0.08s
```

## Reviewers
@backend-team

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914b13e6b4c832f861e1ab2a8609d22)